### PR TITLE
Implement `subsetOf`

### DIFF
--- a/fhirpath/fhirpathtest/fhirpathtest_example_test.go
+++ b/fhirpath/fhirpathtest/fhirpathtest_example_test.go
@@ -3,16 +3,10 @@ package fhirpathtest_test
 import (
 	"errors"
 	"fmt"
-	"testing"
 
 	"github.com/verily-src/fhirpath-go/fhirpath"
 	"github.com/verily-src/fhirpath-go/fhirpath/fhirpathtest"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
-
-	cpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
-	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
-	pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
-	qrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/questionnaire_response_go_proto"
 )
 
 func ExampleError() {
@@ -50,117 +44,4 @@ func ExampleReturnCollection() {
 
 	fmt.Printf("got = %v", bool(got[0].(system.Boolean)))
 	// Output: got = true
-}
-
-// Create a FHIR Patient resource
-var (
-	patientOfficialName = &dtpb.HumanName{
-		Given: []*dtpb.String{
-			{Value: "John"},
-		},
-		Family: &dtpb.String{Value: "Doe"},
-		Use:    &dtpb.HumanName_UseCode{Value: *cpb.NameUseCode_OFFICIAL.Enum()},
-	}
-
-	testPatient = &pb.Patient{
-		Name: []*dtpb.HumanName{
-			patientOfficialName,
-			{
-				Given: []*dtpb.String{
-					{Value: "Johnny"},
-				},
-				Family: &dtpb.String{Value: "Doe"},
-				Use:    &dtpb.HumanName_UseCode{Value: *cpb.NameUseCode_NICKNAME.Enum()},
-			},
-		},
-	}
-
-	testQuestionnaireResponse = &qrpb.QuestionnaireResponse{
-		Item: []*qrpb.QuestionnaireResponse_Item{
-			{
-				Answer: []*qrpb.QuestionnaireResponse_Item_Answer{
-					{Value: &qrpb.QuestionnaireResponse_Item_Answer_ValueX{
-						Choice: &qrpb.QuestionnaireResponse_Item_Answer_ValueX_Coding{
-							Coding: &dtpb.Coding{Code: &dtpb.Code{Value: "foo"}},
-						},
-					}},
-				},
-			},
-		},
-	}
-)
-
-// TestFHIRPathResource is based on issue can't call Evaluate() because fhir.Resource is internal? #18
-// https://github.com/verily-src/fhirpath-go/issues/18
-//
-// Testing that by using only the fhirpath package, we can still evaluate
-// a FHIRPath expression that returns a resource.
-func TestFHIRPathResource(t *testing.T) {
-	want := system.Collection{
-		&dtpb.String{Value: "John"},
-	}
-
-	// Compile the FHIRPath expression
-	expr := fhirpath.MustCompile("name.given")
-
-	// Wrap the Patient resource in a FHIRPath Resource
-	resource := []fhirpath.Resource{testPatient}
-
-	// Evaluate the expression against the Patient resource
-	got, err := expr.Evaluate(resource)
-	if err != nil {
-		t.Errorf("Error evaluating FHIRPath expression: %v", err)
-	}
-
-	// Check if the results match the expected output
-	if len(got) != 2 {
-		t.Errorf("Expected 2 results, got %d", len(got))
-	}
-	gotValue := got[0].(*dtpb.String).GetValue()
-	wantValue := want[0].(*dtpb.String).GetValue()
-	if gotValue != wantValue {
-		t.Errorf("Expected %s, got %s", wantValue, gotValue)
-	}
-}
-
-func TestFHIRPathWhere(t *testing.T) {
-	resource := []fhirpath.Resource{testPatient}
-
-	// Test where: name is official (cpb.NameUseCode_OFFICIAL)
-	exprWhere := fhirpath.MustCompile("name.where(use = 'official')")
-	gotWhere, err := exprWhere.Evaluate(resource)
-	if err != nil {
-		t.Errorf("Error evaluating where: %v", err)
-	}
-	wantWhere := patientOfficialName
-
-	if len(gotWhere) != 1 {
-		t.Errorf("Expected 1 result from where, got %d", len(gotWhere))
-	}
-	if len(gotWhere) == 1 {
-		gotValue := gotWhere[0].(*dtpb.HumanName).GetGiven()[0].GetValue()
-		wantValue := wantWhere.GetGiven()[0].GetValue()
-		if gotValue != wantValue {
-			t.Errorf("Expected %s from where, got %q", wantValue, gotValue)
-		}
-	}
-}
-
-func TestFHIRPathCombine(t *testing.T) {
-	// Use the testQuestionnaireResponse defined above (empty for now, but can be extended)
-	resource := []fhirpath.Resource{testQuestionnaireResponse}
-
-	// Evaluate the FHIRPath expression: QuestionnaireResponse.item.answer.combine(today())
-	expr := fhirpath.MustCompile("item.answer.combine(today())")
-	got, err := expr.Evaluate(resource)
-	if err != nil {
-		t.Fatalf("Error evaluating combine: %v", err)
-	}
-
-	if got == nil {
-		t.Errorf("Expected non-nil result from combine, got nil")
-	}
-	if len(got) != 2 {
-		t.Errorf("Expected 2 results from combine, got %d", len(got))
-	}
 }

--- a/fhirpath/internal/funcs/impl/existence_test.go
+++ b/fhirpath/internal/funcs/impl/existence_test.go
@@ -665,3 +665,321 @@ func TestEmpty_RaisesError(t *testing.T) {
 		})
 	}
 }
+
+func TestSubsetOf_Success(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input system.Collection
+		args  []expr.Expression
+		want  system.Collection
+	}{
+		{
+			name:  "returns true if input is empty",
+			input: system.Collection{},
+			args:  []expr.Expression{exprtest.Return(system.Integer(1), system.Integer(2))},
+			want:  system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false if argument collection is empty but input is not",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+			},
+			args: []expr.Expression{exprtest.Return()},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true if input is subset of argument collection",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false if input is not subset of argument collection",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(5),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true if input equals argument collection",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns true with fhir.Integer types - subset case",
+			input: system.Collection{
+				fhir.Integer(1),
+				fhir.Integer(2),
+			},
+			args: []expr.Expression{exprtest.Return(
+				fhir.Integer(1),
+				fhir.Integer(2),
+				fhir.Integer(3),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false with fhir.Integer types - not subset case",
+			input: system.Collection{
+				fhir.Integer(1),
+				fhir.Integer(4),
+			},
+			args: []expr.Expression{exprtest.Return(
+				fhir.Integer(1),
+				fhir.Integer(2),
+				fhir.Integer(3),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true with mixed system and fhir types",
+			input: system.Collection{
+				system.Integer(1),
+				fhir.Integer(2),
+			},
+			args: []expr.Expression{exprtest.Return(
+				fhir.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns true with string collections - subset case",
+			input: system.Collection{
+				system.String("a"),
+				system.String("b"),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.String("a"),
+				system.String("b"),
+				system.String("c"),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false with string collections - not subset case",
+			input: system.Collection{
+				system.String("a"),
+				system.String("d"),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.String("a"),
+				system.String("b"),
+				system.String("c"),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true with coding collections - subset case",
+			input: system.Collection{
+				fhir.Coding("loinc-system", "loinc-code"),
+				fhir.Coding("snomed-system", "snomed-code"),
+			},
+			args: []expr.Expression{exprtest.Return(
+				fhir.Coding("loinc-system", "loinc-code"),
+				fhir.Coding("snomed-system", "snomed-code"),
+				fhir.Coding("icd10-system", "icd10-code"),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false with coding collections - not subset case",
+			input: system.Collection{
+				fhir.Coding("loinc-system", "loinc-code"),
+				fhir.Coding("missing-system", "missing-code"),
+			},
+			args: []expr.Expression{exprtest.Return(
+				fhir.Coding("loinc-system", "loinc-code"),
+				fhir.Coding("snomed-system", "snomed-code"),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "treats FHIR messages with different field orders as equivalent",
+			input: system.Collection{
+				&dtpb.HumanName{
+					Given:  []*dtpb.String{fhir.String("John")},
+					Family: fhir.String("Doe"),
+				},
+			},
+			args: []expr.Expression{exprtest.Return(
+				&dtpb.HumanName{
+					Family: fhir.String("Doe"),
+					Given:  []*dtpb.String{fhir.String("John")},
+				},
+				&dtpb.HumanName{
+					Given:  []*dtpb.String{fhir.String("Jane")},
+					Family: fhir.String("Smith"),
+				},
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false for large collections - element not in superset",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+				system.Integer(5),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+				system.Integer(6),
+				system.Integer(7),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true for large collections - proper subset",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+				system.Integer(5),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+				system.Integer(4),
+				system.Integer(5),
+				system.Integer(6),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name: "returns false for multiset - duplicate elements in input",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(1),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns false for multiset - input has more duplicates than other collection",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(1),
+				system.Integer(1),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(3),
+			)},
+			want: system.Collection{system.Boolean(false)},
+		},
+		{
+			name: "returns true for multiset - input has fewer duplicates than other collection",
+			input: system.Collection{
+				system.Integer(1),
+				system.Integer(2),
+			},
+			args: []expr.Expression{exprtest.Return(
+				system.Integer(1),
+				system.Integer(1),
+				system.Integer(2),
+				system.Integer(2),
+			)},
+			want: system.Collection{system.Boolean(true)},
+		},
+		{
+			name:  "returns true for single element subset",
+			input: system.Collection{system.Integer(1)},
+			args:  []expr.Expression{exprtest.Return(system.Integer(1), system.Integer(2))},
+			want:  system.Collection{system.Boolean(true)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := impl.SubsetOf(&expr.Context{}, tc.input, tc.args...)
+			if err != nil {
+				t.Errorf("SubsetOf() error = %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("SubsetOf() returned unexpected diff (-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsetOf_Errors(t *testing.T) {
+	testCases := []struct {
+		name            string
+		inputArgs       []expr.Expression
+		inputCollection system.Collection
+		wantErrMsg      string
+	}{
+		{
+			name:            "no arguments provided",
+			inputArgs:       []expr.Expression{},
+			inputCollection: system.Collection{system.Integer(1), system.Integer(2)},
+			wantErrMsg:      "incorrect function arity: received 0 arguments, expected 1",
+		},
+		{
+			name: "multiple arguments provided",
+			inputArgs: []expr.Expression{
+				exprtest.Return(system.Integer(1)),
+				exprtest.Return(system.Integer(2)),
+			},
+			inputCollection: system.Collection{system.Integer(1)},
+			wantErrMsg:      "incorrect function arity: received 2 arguments, expected 1",
+		},
+		{
+			name:            "argument expression raises error",
+			inputArgs:       []expr.Expression{exprtest.Error(errors.New("some error"))},
+			inputCollection: system.Collection{system.Integer(1)},
+			wantErrMsg:      "some error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := impl.SubsetOf(&expr.Context{}, tc.inputCollection, tc.inputArgs...)
+			if err == nil {
+				t.Fatalf("evaluating SubsetOf function didn't return error when expected")
+			}
+
+			if err.Error() != tc.wantErrMsg {
+				t.Errorf("SubsetOf() error = %v, wantErrMsg %v", err, tc.wantErrMsg)
+			}
+		})
+	}
+}

--- a/fhirpath/internal/funcs/table.go
+++ b/fhirpath/internal/funcs/table.go
@@ -56,7 +56,12 @@ var baseTable = FunctionTable{
 		0,
 		false,
 	},
-	"subsetOf":   notImplemented,
+	"subsetOf": Function{
+		impl.SubsetOf,
+		1,
+		1,
+		false,
+	},
 	"supersetOf": notImplemented,
 	"count": Function{
 		impl.Count,

--- a/fhirpath/resolver/resolvertest/resolvertest.go
+++ b/fhirpath/resolver/resolvertest/resolvertest.go
@@ -10,16 +10,19 @@ import (
 
 type resolverFunc func(input []string) ([]fhir.Resource, error)
 
+// Resolve calls the underlying resolverFunc, fulfilling the resolver.Resolver interface.
 func (rf resolverFunc) Resolve(input []string) ([]fhir.Resource, error) {
 	return rf(input)
 }
 
+// HappyResolver returns a resolver.Resolver that always returns the provided resources and no error.
 func HappyResolver(resources ...fhirpath.Resource) resolver.Resolver {
 	return resolverFunc(func(input []string) ([]fhir.Resource, error) {
 		return resources, nil
 	})
 }
 
+// ErroringResolver returns a resolver.Resolver that always returns the given error and no resources.
 func ErroringResolver(err error) resolver.Resolver {
 	return resolverFunc(func(input []string) ([]fhir.Resource, error) {
 		return nil, err

--- a/fhirpath/system/quantity.go
+++ b/fhirpath/system/quantity.go
@@ -120,8 +120,8 @@ func (q Quantity) ToProtoQuantity() *dtpb.Quantity {
 	return res
 }
 
-// TODO: According to our initial investigations, Equal should return empty when value is not set.
 // Equal method to override cmp.Equal.
+// TODO: According to our initial investigations, Equal should return empty when value is not set.
 func (q Quantity) Equal(q2 Quantity) bool {
 	return q.value.Equal(q2.value) && q.unit == q2.unit
 }


### PR DESCRIPTION
Implement the `susbetOf` method based on the N1 spec: https://hl7.org/fhirpath/N1/index.html#subsetofother-collection-boolean
```text
5.1.8. subsetOf(other : collection) : Boolean
Returns true if all items in the input collection are members of the collection passed as the other argument. Membership is determined using the [= (Equals)](https://hl7.org/fhirpath/N1/index.html#equals) (=) operation.

Conceptually, this function is evaluated by testing each element in the input collection for membership in the other collection, with a default of true. This means that if the input collection is empty ({ }), the result is true, otherwise if the other collection is empty ({ }), the result is false.

The following example returns true if the tags defined in any contained resource are a subset of the tags defined in the MedicationRequest resource:

MedicationRequest.contained.meta.tag.subsetOf(MedicationRequest.meta.tag)
```

GitOrigin-RevId: 520ee835d324807ada9458b1e75563cddacb5818