### PR TITLE
Implement '|' (union), 'contains' and 'in' operators

### DIFF
--- a/fhirpath/fhirpath_test.go
+++ b/fhirpath/fhirpath_test.go
@@ -1130,6 +1130,16 @@ func TestFunctionInvocation_Evaluates(t *testing.T) {
 			wantCollection:  system.Collection{system.String("Chu-Chu")},
 			compileOptions:  []fhirpath.CompileOption{compopts.WithExperimentalFuncs()},
 		},
+		{
+			name:            "returns the distinct union of two sets of names",
+			inputPath:       "Patient.name.given | Patient.name.family",
+			inputCollection: []fhirpath.Resource{patientChu},
+			wantCollection: system.Collection{
+				fhir.String("Senpai"),
+				fhir.String("Kang"),
+				fhir.String("Chu"),
+			},
+		},
 	}
 
 	testEvaluate(t, testCases)
@@ -1214,6 +1224,61 @@ func TestTypeExpression_Evaluates(t *testing.T) {
 			inputPath:       "@2000-12-05 as Date",
 			inputCollection: []fhirpath.Resource{},
 			wantCollection:  system.Collection{system.MustParseDate("2000-12-05")},
+		},
+	}
+
+	testEvaluate(t, testCases)
+}
+
+func TestMembershipExpression_Evaluates(t *testing.T) {
+	testCases := []evaluateTestCase{
+		{
+			name:            "returns true for 'in' operator with present value",
+			inputPath:       "'a' in ('a' | 'b' | 'c')",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(true)},
+		},
+		{
+			name:            "returns false for 'in' operator with absent value",
+			inputPath:       "'d' in ('a' | 'b' | 'c')",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(false)},
+		},
+		{
+			name:            "returns empty for 'in' operator with empty left side",
+			inputPath:       "{} in ('a' | 'b' | 'c')",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{},
+		},
+		{
+			name:            "returns false for 'in' operator with empty right side",
+			inputPath:       "'a' in {}",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(false)},
+		},
+		{
+			name:            "returns true for 'contains' operator with present value",
+			inputPath:       "('a' | 'b' | 'c') contains 'b'",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(true)},
+		},
+		{
+			name:            "returns false for 'contains' operator with absent value",
+			inputPath:       "('a' | 'b' | 'c') contains 'd'",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(false)},
+		},
+		{
+			name:            "returns false for 'contains' operator with empty left side",
+			inputPath:       "{} contains 'a'",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{system.Boolean(false)},
+		},
+		{
+			name:            "returns empty for 'contains' operator with empty right side",
+			inputPath:       "('a' | 'b' | 'c') contains {}",
+			inputCollection: []fhirpath.Resource{},
+			wantCollection:  system.Collection{},
 		},
 	}
 

--- a/fhirpath/internal/expr/expressions.go
+++ b/fhirpath/internal/expr/expressions.go
@@ -808,3 +808,76 @@ func (e *NegationExpression) Evaluate(ctx *Context, input system.Collection) (sy
 }
 
 var _ Expression = (*NegationExpression)(nil)
+
+// UnionExpression combines two collections into a single collection, retaining only distinct elements.
+type UnionExpression struct {
+	Left  Expression
+	Right Expression
+}
+
+// MembershipExpression enables evaluation of the "in" and "contains" operators.
+type MembershipExpression struct {
+	Left     Expression
+	Right    Expression
+	Operator Operator
+}
+
+// Evaluate evaluates the left and right subexpressions and performs a membership check
+// according to the FHIRPath specification for 'in' and 'contains'.
+func (e *MembershipExpression) Evaluate(ctx *Context, input system.Collection) (system.Collection, error) {
+	leftResult, err := e.Left.Evaluate(ctx.Clone(), input)
+	if err != nil {
+		return nil, err
+	}
+	rightResult, err := e.Right.Evaluate(ctx.Clone(), input)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.Operator {
+	case In:
+		if leftResult.IsEmpty() {
+			return system.Collection{}, nil
+		}
+		if !leftResult.IsSingleton() {
+			return nil, fmt.Errorf("%w: 'in' operator requires the left operand to be a singleton, but got %d items", ErrNotSingleton, len(leftResult))
+		}
+		return system.Collection{system.Boolean(rightResult.Contains(leftResult[0]))}, nil
+	case Contains:
+		if rightResult.IsEmpty() {
+			return system.Collection{}, nil
+		}
+		if !rightResult.IsSingleton() {
+			return nil, fmt.Errorf("%w: 'contains' operator requires the right operand to be a singleton, but got %d items", ErrNotSingleton, len(rightResult))
+		}
+		return system.Collection{system.Boolean(leftResult.Contains(rightResult[0]))}, nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrInvalidOperator, e.Operator)
+	}
+}
+
+var _ Expression = (*MembershipExpression)(nil)
+
+// Evaluate executes the union expression by evaluating both the left and right expressions,
+// and then combining their results into a single collection with duplicates removed.
+func (e *UnionExpression) Evaluate(ctx *Context, input system.Collection) (system.Collection, error) {
+	leftResult, err := e.Left.Evaluate(ctx.Clone(), input)
+	if err != nil {
+		return nil, err
+	}
+	rightResult, err := e.Right.Evaluate(ctx.Clone(), input)
+	if err != nil {
+		return nil, err
+	}
+
+	// makes sure result is not nil if both inputs are empty or nil
+	result := append(system.Collection{}, leftResult...)
+	for _, item := range rightResult {
+		if !result.Contains(item) {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
+var _ Expression = (*UnionExpression)(nil)

--- a/fhirpath/internal/expr/operators.go
+++ b/fhirpath/internal/expr/operators.go
@@ -23,6 +23,8 @@ const (
 	Div           = "/"
 	FloorDiv      = "div"
 	Mod           = "mod"
+	In            = "in"
+	Contains      = "contains"
 )
 
 // Operator represents a valid expression operator.

--- a/fhirpath/internal/funcs/impl/terminology.go
+++ b/fhirpath/internal/funcs/impl/terminology.go
@@ -15,7 +15,7 @@ var (
 	ErrNotSupported       = errors.New("Not Supported, memberOf must be called on a single Coding or a CodeableConcept")
 )
 
-// MemberOf takes a Coding or a Codeable concept and a ValueSet internal id
+// MemberOf takes a Coding or a CodeableConcept and a ValueSet internal ID
 // and determines if the coding of any of the coding is inside the ValueSet
 func MemberOf(ctx *expr.Context, input system.Collection, args ...expr.Expression) (system.Collection, error) {
 	if length := len(args); length != 1 {
@@ -56,7 +56,7 @@ func MemberOf(ctx *expr.Context, input system.Collection, args ...expr.Expressio
 			validateResult = result
 
 		case *dtpb.CodeableConcept:
-			// If it's a Codeable Concept, we will checking the coding inside one by one
+			// If it's a CodeableConcept, check the coding inside one by one
 			for _, coding := range res.GetCoding() {
 				result, err := validateCoding(ctx, coding.GetCode().GetValue(), coding.GetSystem().GetValue(), valueSetId)
 				if err != nil {

--- a/fhirpath/internal/funcs/table.go
+++ b/fhirpath/internal/funcs/table.go
@@ -62,7 +62,12 @@ var baseTable = FunctionTable{
 		1,
 		false,
 	},
-	"supersetOf": notImplemented,
+	"supersetOf": Function{
+		impl.SupersetOf,
+		1,
+		1,
+		false,
+	},
 	"count": Function{
 		impl.Count,
 		0,

--- a/internal/resource/canonical_identity.go
+++ b/internal/resource/canonical_identity.go
@@ -28,7 +28,6 @@ type CanonicalIdentity struct {
 }
 
 // canonicalTypeMatcher is used to identify if a resource is a canonical resource.
-// This
 type canonicalTypeMatcher interface {
 	GetUrl() *dtpb.Uri
 	GetVersion() *dtpb.String


### PR DESCRIPTION
Copybara-ed version of @Quarz0 PR https://github.com/verily-src/fhirpath-go/pull/25 with some addition changes in regards to some in-code comments. 

> Implement the collections operators: https://hl7.org/fhirpath/N1/#collections-2

Full PR changes:
- https://github.com/verily-src/fhirpath-go/pull/25 by Marwan Tammam (@Quarz0) & integrated by Alexandre Laurin (@alexlaurinmath) 
- Code clean-up by Alexander Sullivan (@AlexJSully)

GitOrigin-RevId: 185c3bcddf8abff6722afb6b5ad02c5a40a8c354