### PR TITLE
Implement trace as a simple pass through - no logging functionality yet

### DIFF
--- a/fhirpath/internal/funcs/impl/utility.go
+++ b/fhirpath/internal/funcs/impl/utility.go
@@ -1,6 +1,8 @@
 package impl
 
 import (
+	"fmt"
+
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 )
@@ -21,4 +23,13 @@ func Today(ctx *expr.Context, input system.Collection, args ...expr.Expression) 
 func Now(ctx *expr.Context, input system.Collection, args ...expr.Expression) (system.Collection, error) {
 	dateTimeString := ctx.Now.Format("2006-01-02T15:04:05.000Z07:00")
 	return system.Collection{system.MustParseDateTime(dateTimeString)}, nil
+}
+
+// Trace adds a String representation of the input collection to the diagnostic log.
+func Trace(ctx *expr.Context, input system.Collection, args ...expr.Expression) (system.Collection, error) {
+	if len(args) < 1 || len(args) > 2 {
+		return nil, fmt.Errorf("%w: received %v arguments, expected 1 or 2", ErrWrongArity, len(args))
+	}
+	// TODO: Implement diagnostic logging functionality of trace.
+	return input, nil
 }

--- a/fhirpath/internal/funcs/table.go
+++ b/fhirpath/internal/funcs/table.go
@@ -396,7 +396,12 @@ var baseTable = FunctionTable{
 		0,
 		false,
 	},
-	"trace": notImplemented,
+	"trace": Function{
+		impl.Trace,
+		1,
+		2,
+		false,
+	},
 	"now": Function{
 		impl.Now,
 		0,


### PR DESCRIPTION
This should just make expressions that have the trace function be able to compile and evaluate without the actual debugging capability of trace