### PR TITLE
Implement `trace` and fix some FHIRPath expression evaluation issues

### DIFF
--- a/fhirpath/compopts/compopts.go
+++ b/fhirpath/compopts/compopts.go
@@ -57,6 +57,15 @@ func Permissive() opts.CompileOption {
 	})
 }
 
+// SkipUnknownFields is an option that allows for skipping unknown fields and returning
+// an empty collection instead of throwing an error.
+func SkipUnknownFields() opts.CompileOption {
+	return opts.Transform(func(cfg *opts.CompileConfig) error {
+		cfg.SkipUnknownFields = true
+		return nil
+	})
+}
+
 // WithExperimentalFuncs is an option that enables experimental functions not
 // in the N1 Normative specification.
 func WithExperimentalFuncs() opts.CompileOption {

--- a/fhirpath/evalopts/evalopts.go
+++ b/fhirpath/evalopts/evalopts.go
@@ -16,6 +16,7 @@ import (
 	"github.com/verily-src/fhirpath-go/fhirpath/resolver"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 	"github.com/verily-src/fhirpath-go/fhirpath/terminology"
+	"github.com/verily-src/fhirpath-go/fhirpath/trace"
 	"github.com/verily-src/fhirpath-go/internal/fhir"
 )
 
@@ -88,6 +89,15 @@ func WithResolver(resolver resolver.Resolver) opts.EvaluateOption {
 func WithTerminologyService(termService terminology.Service) opts.EvaluateOption {
 	return opts.Transform(func(cfg *opts.EvaluateConfig) error {
 		cfg.Context.TermService = termService
+		return nil
+	})
+}
+
+// WithTracer returns an EvaluationOption that sets a [trace.Tracer] to use for the "trace"
+// fhirpath function.
+func WithTracer(tracer trace.Tracer) opts.EvaluateOption {
+	return opts.Transform(func(cfg *opts.EvaluateConfig) error {
+		cfg.Context.Tracer = tracer
 		return nil
 	})
 }

--- a/fhirpath/fhirpath.go
+++ b/fhirpath/fhirpath.go
@@ -47,8 +47,9 @@ func Compile(expr string, options ...CompileOption) (*Expression, error) {
 	}
 
 	visitor := &parser.FHIRPathVisitor{
-		Functions:  config.Table,
-		Permissive: config.Permissive,
+		Functions:         config.Table,
+		Permissive:        config.Permissive,
+		SkipUnknownFields: config.SkipUnknownFields,
 	}
 	vr, ok := visitor.Visit(tree).(*parser.VisitResult)
 	if !ok {

--- a/fhirpath/fhirpath_test.go
+++ b/fhirpath/fhirpath_test.go
@@ -74,6 +74,9 @@ var (
 				Family: fhir.String("Chu"),
 			},
 		},
+		Text: &dtpb.Narrative{
+			Div: &dtpb.Xhtml{Value: "patient chu record"},
+		},
 		Contact: []*ppb.Patient_Contact{
 			{
 				Name: &dtpb.HumanName{
@@ -83,9 +86,11 @@ var (
 			},
 		},
 	}
+
 	fooExtension, _ = extension.FromElement("foourl", fhir.String("foovalue"))
 	barExtension, _ = extension.FromElement("barurl", fhir.String("barvalue"))
-	nameVoldemort   = &dtpb.HumanName{
+
+	nameVoldemort = &dtpb.HumanName{
 		Given: []*dtpb.String{
 			fhir.String("Lord"),
 		},
@@ -135,7 +140,15 @@ var (
 				},
 			},
 		},
+		RelatesTo: []*drpb.DocumentReference_RelatesTo{
+			{
+				Code: &drpb.DocumentReference_RelatesTo_CodeType{
+					Value: cpb.DocumentRelationshipTypeCode_APPENDS,
+				},
+			},
+		},
 	}
+
 	questionnaireRef, _ = reference.Typed("Questionnaire", "1234")
 	obsWithRef          = &opb.Observation{
 		Meta: &dtpb.Meta{
@@ -456,7 +469,20 @@ func TestEvaluate_PathSelection_ReturnsResult(t *testing.T) {
 			inputCollection: []fhirpath.Resource{task},
 			wantCollection:  system.Collection{system.String(fhirconv.DateTimeToString(end.ToProtoDateTime()))},
 		},
+		{
+			name:            "delimited identifier",
+			inputPath:       "Patient.text.`div`",
+			inputCollection: []fhirpath.Resource{patientChu},
+			wantCollection:  system.Collection{fhir.Xhtml("patient chu record")},
+		},
+		{
+			name:            "escaping backticks",
+			inputPath:       "Patient.text.`div`.contains('\\`')",
+			inputCollection: []fhirpath.Resource{patientChu},
+			wantCollection:  system.Collection{system.Boolean(false)},
+		},
 	}
+
 	testEvaluate(t, testCases)
 }
 
@@ -1070,6 +1096,13 @@ func TestFunctionInvocation_Evaluates(t *testing.T) {
 			wantCollection:  system.Collection{system.Boolean(false), system.Boolean(true)},
 		},
 		{
+			name:            "filtering nested fields by field name",
+			inputPath:       "descendants().family",
+			inputCollection: []fhirpath.Resource{patientChu},
+			compileOptions:  []fhirpath.CompileOption{compopts.SkipUnknownFields()},
+			wantCollection:  system.Collection{patientChu.Name[0].Family, patientChu.Name[1].Family, patientChu.Contact[0].Name.Family},
+		},
+		{
 			name:            "returns last item repeatedly",
 			inputPath:       "repeat(children().last())",
 			inputCollection: []fhirpath.Resource{patientChu},
@@ -1319,6 +1352,12 @@ func TestTypeExpression_Evaluates(t *testing.T) {
 			inputPath:       "@2000-12-05 as Date",
 			inputCollection: []fhirpath.Resource{},
 			wantCollection:  system.Collection{system.MustParseDate("2000-12-05")},
+		},
+		{
+			name:            "passes through as code",
+			inputPath:       "relatesTo.code as code",
+			inputCollection: []fhirpath.Resource{docRef},
+			wantCollection:  system.Collection{docRef.RelatesTo[0].Code},
 		},
 	}
 
@@ -1584,6 +1623,10 @@ func TestCompile_ReturnsError(t *testing.T) {
 		{
 			name:      "resolving invalid type specifier",
 			inputPath: "1 is System.Patient",
+		},
+		{
+			name:      "reserved keyword not delimited",
+			inputPath: "Patient.text.div",
 		},
 	}
 

--- a/fhirpath/internal/expr/context.go
+++ b/fhirpath/internal/expr/context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/verily-src/fhirpath-go/fhirpath/resolver"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 	"github.com/verily-src/fhirpath-go/fhirpath/terminology"
+	"github.com/verily-src/fhirpath-go/fhirpath/trace"
 )
 
 // Context holds the global time and external constant
@@ -31,9 +32,20 @@ type Context struct {
 	// is used in the 'resolve()' FHIRPath function.
 	Resolver resolver.Resolver
 
+	// Permissive is a legacy option to allow FHIRpaths with *invalid* fields to be
+	// compiled (to reduce breakages).
+	Permissive bool
+
+	// SkipUnknownFields is an option that allows for skipping unknown fields and returning
+	// an empty collection instead of throwing an error.
+	SkipUnknownFields bool
+
 	// Service is an optional mechanism for providing a terminology service
 	// which can be used to validate code in valueSet
 	TermService terminology.Service
+
+	// Tracer is an optional mechanism for tracing FHIRPath evaluation
+	Tracer trace.Tracer
 
 	// GoContext is a context from the calling main function
 	GoContext context.Context
@@ -66,6 +78,8 @@ func (c *Context) Clone() *Context {
 		ExternalConstants: c.ExternalConstants,
 		LastResult:        c.LastResult,
 		Resolver:          c.Resolver,
+		Permissive:        c.Permissive,
+		SkipUnknownFields: c.SkipUnknownFields,
 		TermService:       c.TermService,
 		GoContext:         c.GoContext,
 	}
@@ -77,8 +91,10 @@ func InitializeContext(input system.Collection) *Context {
 	return &Context{
 		Now: time.Now().Local().UTC(),
 		ExternalConstants: map[string]any{
-			"context": input,
-			"ucum":    system.String("http://unitsofmeasure.org"),
+			"context":      input,
+			"rootResource": input,
+			"ucum":         system.String("http://unitsofmeasure.org"),
 		},
+		Tracer: trace.NoopTracer(),
 	}
 }

--- a/fhirpath/internal/expr/expressions.go
+++ b/fhirpath/internal/expr/expressions.go
@@ -7,8 +7,8 @@ import (
 
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
 	bcrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
-	"github.com/iancoleman/strcase"
-	"github.com/shopspring/decimal"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/reflection"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 	"github.com/verily-src/fhirpath-go/internal/containedresource"
@@ -16,7 +16,9 @@ import (
 	"github.com/verily-src/fhirpath-go/internal/fhirconv"
 	"github.com/verily-src/fhirpath-go/internal/protofields"
 	"github.com/verily-src/fhirpath-go/internal/slices"
-	"google.golang.org/protobuf/proto"
+
+	"github.com/iancoleman/strcase"
+	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -77,8 +79,9 @@ var _ Expression = (*IdentityExpression)(nil)
 // FieldExpression is the expression that accesses the specified
 // FieldName in the input collection.
 type FieldExpression struct {
-	FieldName  string
-	Permissive bool
+	FieldName         string
+	Permissive        bool
+	SkipUnknownFields bool
 }
 
 // Evaluate filters the input collections by those that contain
@@ -161,6 +164,10 @@ func (e *FieldExpression) Evaluate(ctx *Context, input system.Collection) (syste
 			fieldName = fieldName + "_value"
 			field = reflect.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
 			if field == nil {
+				if e.SkipUnknownFields {
+					continue
+				}
+
 				return nil, fmt.Errorf("%w: %s not a field on %T", ErrInvalidField, fieldName, message)
 			}
 		}
@@ -442,8 +449,10 @@ var _ Expression = (*EqualityExpression)(nil)
 // FunctionExpression enables evaluation of Function Invocation expressions.
 // It holds the function and function arguments.
 type FunctionExpression struct {
-	Fn   func(*Context, system.Collection, ...Expression) (system.Collection, error)
-	Args []Expression
+	Fn                func(*Context, system.Collection, ...Expression) (system.Collection, error)
+	Args              []Expression
+	Permissive        bool
+	SkipUnknownFields bool
 }
 
 // Evaluate evaluates the function with respect to its arguments. Returns the result

--- a/fhirpath/internal/expr/expressions_test.go
+++ b/fhirpath/internal/expr/expressions_test.go
@@ -8,15 +8,12 @@ import (
 
 	cpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
-	"github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
 	bcrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
-	"github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/device_go_proto"
+	dpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/device_go_proto"
 	epb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/encounter_go_proto"
 	mrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/medication_request_go_proto"
-	"github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
 	ppb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/shopspring/decimal"
+
 	"github.com/verily-src/fhirpath-go/fhirpath"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr/exprtest"
@@ -27,6 +24,9 @@ import (
 	"github.com/verily-src/fhirpath-go/internal/fhir"
 	"github.com/verily-src/fhirpath-go/internal/fhirconv"
 	"github.com/verily-src/fhirpath-go/internal/slices"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -211,6 +211,12 @@ func TestFieldExpression_Gets_DesiredField(t *testing.T) {
 			wantCollection: system.Collection{patientBirthDay},
 		},
 		{
+			name:           "input item doesn't have field - skipped",
+			fieldExp:       &expr.FieldExpression{FieldName: "given", SkipUnknownFields: true},
+			input:          system.Collection{patientFirstHumanName, patientContactPoint[0]},
+			wantCollection: system.Collection{patientFirstHumanName.Given[0], patientFirstHumanName.Given[1]},
+		},
+		{
 			name:           "(Legacy) input contains non-resource items",
 			fieldExp:       &expr.FieldExpression{FieldName: "birthDate", Permissive: true},
 			input:          system.Collection{patientMissingName, "hello"},
@@ -252,15 +258,16 @@ func TestFieldExpression_Gets_DesiredField(t *testing.T) {
 
 func TestFieldExpression_ValidInput_GetsField(t *testing.T) {
 	tm := time.Now()
-	device1 := &device_go_proto.Device{
+	device1 := &dpb.Device{
 		Id: fhir.RandomID(),
 	}
-	patient1 := &patient_go_proto.Patient{
+	patient1 := &ppb.Patient{
 		Id: fhir.RandomID(),
 	}
-	entries := []*bundle_and_contained_resource_go_proto.Bundle_Entry{
+	entries := []*bcrpb.Bundle_Entry{
 		bundle.NewPostEntry(device1), bundle.NewPostEntry(patient1),
 	}
+
 	testCases := []struct {
 		name  string
 		input system.Collection

--- a/fhirpath/internal/funcs/impl/navigation.go
+++ b/fhirpath/internal/funcs/impl/navigation.go
@@ -43,8 +43,10 @@ func Children(ctx *expr.Context, input system.Collection, args ...expr.Expressio
 				fields = append(fields, fd.Get(i).JSONName())
 			}
 		}
+
 		for _, f := range fields {
-			fe := expr.FieldExpression{FieldName: f}
+			fe := expr.FieldExpression{FieldName: f, Permissive: ctx.Permissive, SkipUnknownFields: ctx.SkipUnknownFields}
+
 			messages, err := fe.Evaluate(ctx, system.Collection{base})
 			if err != nil {
 				return nil, err

--- a/fhirpath/internal/funcs/impl/projection.go
+++ b/fhirpath/internal/funcs/impl/projection.go
@@ -31,7 +31,7 @@ func Select(ctx *expr.Context, input system.Collection, args ...expr.Expression)
 		result = append(result, output...)
 	}
 	// Raise field errors if one was raised for each input.
-	if len(input) > 0 && len(fieldErrs) == len(input) {
+	if len(input) > 0 && len(fieldErrs) == len(input) && !ctx.SkipUnknownFields {
 		return nil, errors.Join(fieldErrs...)
 	}
 	return result, nil

--- a/fhirpath/internal/funcs/impl/projection_test.go
+++ b/fhirpath/internal/funcs/impl/projection_test.go
@@ -77,6 +77,12 @@ func TestSelect_Evaluates(t *testing.T) {
 			inputArgs:       []expr.Expression{&expr.FieldExpression{FieldName: "state"}},
 			wantCollection:  system.Collection{address[0].GetState()},
 		},
+		{
+			name:            "does not raise error if all fields are invalid but SkipUnknownFields is true",
+			inputCollection: system.Collection{address[0], fhir.String("string")},
+			inputArgs:       []expr.Expression{&expr.FieldExpression{FieldName: "foo", SkipUnknownFields: true}},
+			wantCollection:  system.Collection{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/fhirpath/internal/funcs/impl/terminology.go
+++ b/fhirpath/internal/funcs/impl/terminology.go
@@ -35,12 +35,12 @@ func MemberOf(ctx *expr.Context, input system.Collection, args ...expr.Expressio
 		return nil, fmt.Errorf("empty argument content")
 	}
 
-	var valueSetId string
+	var valueSetID string
 	switch content[0].(type) {
 	case system.String:
-		valueSetId = string(content[0].(system.String))
+		valueSetID = string(content[0].(system.String))
 	case *dtpb.String:
-		valueSetId = content[0].(*dtpb.String).GetValue()
+		valueSetID = content[0].(*dtpb.String).GetValue()
 	default:
 		return nil, fmt.Errorf("unsupported argument type")
 	}
@@ -49,19 +49,20 @@ func MemberOf(ctx *expr.Context, input system.Collection, args ...expr.Expressio
 	for _, item := range input {
 		switch res := item.(type) {
 		case *dtpb.Coding:
-			result, err := validateCoding(ctx, res.GetCode().GetValue(), res.GetSystem().GetValue(), valueSetId)
+			result, err := validateCoding(ctx, res.GetCode().GetValue(), res.GetSystem().GetValue(), valueSetID)
 			if err != nil {
 				return system.Collection{system.Boolean(false)}, nil
 			}
-			validateResult = result
 
+			validateResult = result
 		case *dtpb.CodeableConcept:
 			// If it's a CodeableConcept, check the coding inside one by one
 			for _, coding := range res.GetCoding() {
-				result, err := validateCoding(ctx, coding.GetCode().GetValue(), coding.GetSystem().GetValue(), valueSetId)
+				result, err := validateCoding(ctx, coding.GetCode().GetValue(), coding.GetSystem().GetValue(), valueSetID)
 				if err != nil {
 					continue
 				}
+
 				if result {
 					validateResult = result
 					break

--- a/fhirpath/internal/funcs/impl/utility.go
+++ b/fhirpath/internal/funcs/impl/utility.go
@@ -1,6 +1,8 @@
 package impl
 
 import (
+	"fmt"
+
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 )
@@ -21,4 +23,45 @@ func Today(ctx *expr.Context, input system.Collection, args ...expr.Expression) 
 func Now(ctx *expr.Context, input system.Collection, args ...expr.Expression) (system.Collection, error) {
 	dateTimeString := ctx.Now.Format("2006-01-02T15:04:05.000Z07:00")
 	return system.Collection{system.MustParseDateTime(dateTimeString)}, nil
+}
+
+// Trace implements the fhirpath "trace" function, which enables custom diagnostic
+// logging during FHIRPath evaluation.
+//
+// For full information, see:
+// https://hl7.org/fhirpath/N1/#tracename-string-projection-expression-collection
+func Trace(ctx *expr.Context, input system.Collection, args ...expr.Expression) (system.Collection, error) {
+	if length := len(args); length < 1 {
+		return nil, fmt.Errorf("%w: received %d arguments, expected minimum 1", ErrWrongArity, length)
+	} else if length > 2 {
+		return nil, fmt.Errorf("%w: received %d arguments, expected maximum 2", ErrWrongArity, length)
+	}
+
+	if ctx.Tracer == nil {
+		return input, nil
+	}
+	nameArg, err := args[0].Evaluate(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	name, err := nameArg.ToString()
+	if err != nil {
+		return nil, err
+	}
+
+	result := input
+	if len(args) == 2 {
+		result = system.Collection{}
+		projection := args[1]
+		for _, entry := range input {
+			r, err := projection.Evaluate(ctx, system.Collection{entry})
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, r...)
+		}
+	}
+	ctx.Tracer.Trace(ctx.GoContext, name, result)
+
+	return input, nil
 }

--- a/fhirpath/internal/funcs/impl/utility_test.go
+++ b/fhirpath/internal/funcs/impl/utility_test.go
@@ -1,13 +1,18 @@
 package impl_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr"
+	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr/exprtest"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/funcs/impl"
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
+	"github.com/verily-src/fhirpath-go/fhirpath/trace"
+	"github.com/verily-src/fhirpath-go/fhirpath/trace/tracetest"
 )
 
 func TestTimeOfDay(t *testing.T) {
@@ -46,5 +51,164 @@ func TestNow(t *testing.T) {
 	}
 	if !cmp.Equal(got, wantCollection) {
 		t.Errorf("impl.Now() returned unexpected result: got %v, want %v", got, wantCollection)
+	}
+}
+
+func TestTrace(t *testing.T) {
+	t.Parallel()
+
+	testErr := errors.New("test error")
+	testName := "test-name"
+	testCases := []struct {
+		name      string
+		tracer    trace.Tracer
+		input     system.Collection
+		args      []expr.Expression
+		want      system.Collection
+		wantTrace system.Collection
+		wantErr   error
+	}{
+		{
+			name:   "Too few arguments",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args:    []expr.Expression{},
+			wantErr: impl.ErrWrongArity,
+		}, {
+			name:   "Too many arguments",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String("test")),
+				exprtest.Return(system.String("test")),
+				exprtest.Return(system.String("test")),
+			},
+			wantErr: impl.ErrWrongArity,
+		}, {
+			name:   "Tracer is not set in context, returns input collection",
+			tracer: nil,
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String("test")),
+			},
+			want: system.Collection{
+				system.String("input value"),
+			},
+		}, {
+			name:   "Name argument does not evaluate to single value",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(
+					system.String("one"),
+					system.String("two"),
+				),
+			},
+			wantErr: cmpopts.AnyError,
+		}, {
+			name:   "Name argument does not evaluate to string",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.Integer(42)),
+			},
+			wantErr: cmpopts.AnyError,
+		}, {
+			name:   "Name argument fails to evaluate",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Error(testErr),
+			},
+			wantErr: testErr,
+		}, {
+			name:   "Projection argument fails to evaluate",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String("test-name")),
+				exprtest.Error(testErr),
+			},
+			wantErr: testErr,
+		}, {
+			name:   "Projection argument returns new value",
+			tracer: trace.NoopTracer(),
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String("test-name")),
+				exprtest.Return(system.String("new value")),
+			},
+			want: system.Collection{
+				system.String("input value"),
+			},
+		}, {
+			name:   "Valid trace without projection",
+			tracer: &tracetest.Recorder{},
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String(testName)),
+			},
+			want: system.Collection{
+				system.String("input value"),
+			},
+			wantTrace: system.Collection{
+				system.String("input value"),
+			},
+		}, {
+			name:   "Valid trace with projection",
+			tracer: &tracetest.Recorder{},
+			input: system.Collection{
+				system.String("input value"),
+			},
+			args: []expr.Expression{
+				exprtest.Return(system.String(testName)),
+				exprtest.Return(system.String("projected value")),
+			},
+			want: system.Collection{
+				system.String("input value"),
+			},
+			wantTrace: system.Collection{
+				system.String("projected value"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &expr.Context{Tracer: tc.tracer}
+
+			collection, err := impl.Trace(ctx, tc.input, tc.args...)
+
+			if got, want := err, tc.wantErr; !cmp.Equal(got, want, cmpopts.EquateErrors()) {
+				t.Fatalf("impl.Trace() got error %v, want %v", got, want)
+			}
+			if got, want := collection, tc.want; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
+				t.Errorf("impl.Trace() got collection %v, want %v", got, want)
+			}
+			if reporter, ok := tc.tracer.(*tracetest.Recorder); ok {
+				if got, want := reporter.Collection(testName), tc.wantTrace; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
+					t.Errorf("impl.Trace() tracer got collection %v, want %v", got, want)
+				}
+			}
+		})
 	}
 }

--- a/fhirpath/internal/funcs/table.go
+++ b/fhirpath/internal/funcs/table.go
@@ -406,7 +406,12 @@ var baseTable = FunctionTable{
 		0,
 		false,
 	},
-	"trace": notImplemented,
+	"trace": Function{
+		impl.Trace,
+		1,
+		2,
+		false,
+	},
 	"now": Function{
 		impl.Now,
 		0,

--- a/fhirpath/internal/opts/opts.go
+++ b/fhirpath/internal/opts/opts.go
@@ -23,6 +23,10 @@ type CompileConfig struct {
 	// Permissive is a legacy option to allow FHIRpaths with *invalid* fields to be
 	// compiled (to reduce breakages).
 	Permissive bool
+
+	// SkipUnknownFields is an option that allows for skipping unknown fields and returning
+	// an empty collection instead of throwing an error.
+	SkipUnknownFields bool
 }
 
 // EvaluateConfig provides the configuration values for the Evaluate command.

--- a/fhirpath/internal/parser/visitor.go
+++ b/fhirpath/internal/parser/visitor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/antlr4-go/antlr/v4"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/expr"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/funcs"
 	"github.com/verily-src/fhirpath-go/fhirpath/internal/funcs/impl"
@@ -14,6 +13,8 @@ import (
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 	"github.com/verily-src/fhirpath-go/internal/resource"
 	"github.com/verily-src/fhirpath-go/internal/slices"
+
+	"github.com/antlr4-go/antlr/v4"
 )
 
 var (
@@ -25,10 +26,11 @@ var (
 
 type FHIRPathVisitor struct {
 	*grammar.BasefhirpathVisitor
-	visitedRoot bool
-	Functions   funcs.FunctionTable
-	Transform   VisitorTransform
-	Permissive  bool
+	visitedRoot       bool
+	Functions         funcs.FunctionTable
+	Transform         VisitorTransform
+	Permissive        bool
+	SkipUnknownFields bool
 }
 
 type VisitResult struct {
@@ -44,10 +46,11 @@ type typeResult struct {
 // clone produces a shallow-clone of the visitor, to be used when visiting sub-expressions.
 func (v *FHIRPathVisitor) clone() *FHIRPathVisitor {
 	return &FHIRPathVisitor{
-		Functions:   v.Functions,
-		Transform:   v.Transform,
-		Permissive:  v.Permissive,
-		visitedRoot: false,
+		Functions:         v.Functions,
+		Transform:         v.Transform,
+		Permissive:        v.Permissive,
+		SkipUnknownFields: v.SkipUnknownFields,
+		visitedRoot:       false,
 	}
 }
 
@@ -443,13 +446,19 @@ func (v *FHIRPathVisitor) VisitExternalConstant(ctx *grammar.ExternalConstantCon
 // root of the expression. If so, it will return a TypeExpression. Otherwise, it returns a FieldExpression.
 func (v *FHIRPathVisitor) VisitMemberInvocation(ctx *grammar.MemberInvocationContext) interface{} {
 	identifier := ctx.GetText()
+
+	if ctx.Identifier().DELIMITEDIDENTIFIER() != nil {
+		identifier = strings.TrimPrefix(identifier, "`")
+		identifier = strings.TrimSuffix(identifier, "`")
+	}
+
 	var expression expr.Expression
 
 	if resource.IsType(identifier) && !v.visitedRoot {
 		expression = &expr.TypeExpression{Type: identifier}
 		v.visitedRoot = true
 	} else {
-		expression = &expr.FieldExpression{FieldName: identifier, Permissive: v.Permissive}
+		expression = &expr.FieldExpression{FieldName: identifier, Permissive: v.Permissive, SkipUnknownFields: v.SkipUnknownFields}
 	}
 
 	return v.transformedVisitResult(expression)
@@ -502,8 +511,10 @@ func (v *FHIRPathVisitor) VisitFunction(ctx *grammar.FunctionContext) interface{
 
 		return v.transformedVisitResult(
 			&expr.FunctionExpression{
-				Fn:   fn.Func,
-				Args: []expr.Expression{&expr.TypeExpression{Type: typeSpecifier.String()}},
+				Fn:                fn.Func,
+				Args:              []expr.Expression{&expr.TypeExpression{Type: typeSpecifier.String()}},
+				Permissive:        v.Permissive,
+				SkipUnknownFields: v.SkipUnknownFields,
 			},
 		)
 	}
@@ -522,7 +533,8 @@ func (v *FHIRPathVisitor) VisitFunction(ctx *grammar.FunctionContext) interface{
 	if len(expressions) < fn.MinArity || len(expressions) > fn.MaxArity {
 		return &VisitResult{nil, fmt.Errorf("%w: input arity outside of function arity bounds", impl.ErrWrongArity)}
 	}
-	return v.transformedVisitResult(&expr.FunctionExpression{Fn: fn.Func, Args: expressions})
+
+	return v.transformedVisitResult(&expr.FunctionExpression{Fn: fn.Func, Args: expressions, Permissive: v.Permissive, SkipUnknownFields: v.SkipUnknownFields})
 }
 
 func (v *FHIRPathVisitor) VisitParamList(ctx *grammar.ParamListContext) interface{} {

--- a/fhirpath/resolver/bundleresolver.go
+++ b/fhirpath/resolver/bundleresolver.go
@@ -172,8 +172,10 @@ func getLatestResource(resources []fhir.Resource) (fhir.Resource, error) {
 		if res.GetMeta().GetLastUpdated() == nil {
 			return nil, ErrMissingMetaOrLastUpdated
 		}
+
 		resLastUpdated := res.GetMeta().GetLastUpdated().GetValueUs()
-		if resolvedLastUpdated > resLastUpdated {
+
+		if resolvedLastUpdated < resLastUpdated {
 			resolvedResource = res
 			resolvedLastUpdated = resLastUpdated
 		}

--- a/fhirpath/resolver/bundleresolver_test.go
+++ b/fhirpath/resolver/bundleresolver_test.go
@@ -6,13 +6,15 @@ import (
 	cpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
 	r4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
-	"github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/observation_go_proto"
+	opb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/observation_go_proto"
 	ppb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/verily-src/fhirpath-go/fhirpath/resolver"
 	"github.com/verily-src/fhirpath-go/internal/containedresource"
 	"github.com/verily-src/fhirpath-go/internal/fhir"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -38,7 +40,7 @@ func TestBundleResolver_Resolve(t *testing.T) {
 	obsAbsVersionedUrl := "https://healthcare.googleapis.com/v1/projects/123/locations/abc/datasets/def/fhirStores/ghi/fhir/Observation/123/_history/v1"
 	invalidVersionedAbsUrl := "https://healthcare.googleapis.com/v1/projects/123/locations/abc/datasets/def/fhirStores/ghi/fhir/Patient/123/_history/%#@^%$#"
 
-	obs123 := &observation_go_proto.Observation{
+	obs123 := &opb.Observation{
 		Id: &dtpb.Id{Value: "123"},
 		Subject: &dtpb.Reference{
 			Reference: &dtpb.Reference_PatientId{PatientId: &dtpb.ReferenceId{Value: "123"}},
@@ -56,7 +58,7 @@ func TestBundleResolver_Resolve(t *testing.T) {
 	patient123Latest := &ppb.Patient{
 		Id: fhir.ID("123"),
 		Meta: &dtpb.Meta{
-			LastUpdated: &dtpb.Instant{ValueUs: 500},
+			LastUpdated: &dtpb.Instant{ValueUs: 5000},
 		},
 	}
 

--- a/fhirpath/system/types.go
+++ b/fhirpath/system/types.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
-	"github.com/shopspring/decimal"
+
 	"github.com/verily-src/fhirpath-go/internal/fhir"
 	"github.com/verily-src/fhirpath-go/internal/fhirconv"
 	"github.com/verily-src/fhirpath-go/internal/protofields"
+
+	"github.com/shopspring/decimal"
 )
 
 var (
@@ -52,7 +54,7 @@ func IsPrimitive(input any) bool {
 	switch v := input.(type) {
 	case *dtpb.Boolean, *dtpb.String, *dtpb.Uri, *dtpb.Url, *dtpb.Canonical, *dtpb.Code, *dtpb.Oid, *dtpb.Id, *dtpb.Uuid, *dtpb.Markdown,
 		*dtpb.Base64Binary, *dtpb.Integer, *dtpb.UnsignedInt, *dtpb.PositiveInt, *dtpb.Decimal, *dtpb.Date,
-		*dtpb.Time, *dtpb.DateTime, *dtpb.Instant, *dtpb.Quantity, Any:
+		*dtpb.Time, *dtpb.DateTime, *dtpb.Instant, *dtpb.Quantity, *dtpb.Xhtml, Any:
 		return true
 	case fhir.Base:
 		return protofields.IsCodeField(v)
@@ -94,6 +96,8 @@ func From(input any) (Any, error) {
 		return Integer(v.Value), nil
 	case *dtpb.PositiveInt:
 		return Integer(v.Value), nil
+	case *dtpb.Xhtml:
+		return String(v.Value), nil
 	case *dtpb.Decimal:
 		value, err := decimal.NewFromString(v.Value)
 		if err != nil {

--- a/fhirpath/system/types_test.go
+++ b/fhirpath/system/types_test.go
@@ -8,11 +8,13 @@ import (
 	mrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/medication_request_go_proto"
 	ppb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
 	qpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/questionnaire_go_proto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/shopspring/decimal"
+
 	"github.com/verily-src/fhirpath-go/fhirpath/system"
 	"github.com/verily-src/fhirpath-go/internal/element/canonical"
 	"github.com/verily-src/fhirpath-go/internal/fhir"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shopspring/decimal"
 )
 
 var (
@@ -95,6 +97,12 @@ var testCases []testCase = []testCase{
 		name:       "converts base64 binary",
 		input:      fhir.Base64Binary([]byte("hello world")),
 		want:       system.String("aGVsbG8gd29ybGQ="),
+		shouldCast: true,
+	},
+	{
+		name:       "converts xhtml",
+		input:      fhir.Xhtml("xhtml"),
+		want:       system.String("xhtml"),
 		shouldCast: true,
 	},
 	{

--- a/fhirpath/trace/trace.go
+++ b/fhirpath/trace/trace.go
@@ -1,0 +1,92 @@
+/*
+Package trace provides utilities for customizing the FHIRPath "trace" function.
+
+This enables callers to define custom mechanisms for logging or recording
+the evaluation steps of FHIRPath expressions, which can be useful for debugging
+or analysis purposes.
+*/
+package trace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/verily-src/fhirpath-go/fhirpath/fhirjson"
+	"github.com/verily-src/fhirpath-go/fhirpath/system"
+	"github.com/verily-src/fhirpath-go/internal/fhir"
+)
+
+// Tracer is an abstraction over the FHIRPath "trace" functionality.
+//
+// Implementations of Tracer objects are provided the name of the trace (if
+// specified in the function call), along with the value(s) that exist at that
+// point in the evaluation.
+//
+// Tracer operations are not allowed to fail or modify the evaluation state in
+// any way.
+type Tracer interface {
+	// Trace is called to record a trace event during FHIRPath evaluation.
+	//
+	// The name parameter is the optional name provided in the trace function
+	// call; it may be an empty string if no name was specified.
+	Trace(ctx context.Context, name string, value system.Collection)
+}
+
+// TracerFunc is an adapter to allow the use of ordinary functions as Tracer.
+type TracerFunc func(ctx context.Context, name string, value system.Collection)
+
+// Trace calls f(ctx, name, value).
+func (f TracerFunc) Trace(ctx context.Context, name string, value system.Collection) {
+	f(ctx, name, value)
+}
+
+// NoopTracer returns a Tracer implementation that performs no operations.
+func NoopTracer() Tracer {
+	return TracerFunc(func(context.Context, string, system.Collection) {
+		// No-op
+	})
+}
+
+// WriterTracer is a Tracer implementation that writes trace information
+// to the provided [io.Writer].
+//
+// Output is logged in non-minified JSON format, with one JSON object per line.
+// If a name was provided to the Trace functionality, the start of the collection
+// of entries is prefixed with the name followed by a colon.
+type WriterTracer struct {
+	Out io.Writer
+
+	m sync.Mutex
+}
+
+// Trace writes the trace information to the configured output writer.
+func (wt *WriterTracer) Trace(_ context.Context, name string, value system.Collection) {
+	wt.m.Lock()
+	defer wt.m.Unlock()
+	var out io.Writer = os.Stdout
+	if wt.Out != nil {
+		out = wt.Out
+	}
+
+	if name != "" {
+		_, _ = fmt.Fprintln(out, name+":")
+	}
+	encoder := json.NewEncoder(out)
+	fhirEncoder := fhirjson.NewEncoder(out)
+	fhirEncoder.SetIndent("", "  ")
+	encoder.SetIndent("", "  ")
+	for _, entry := range value {
+		switch v := entry.(type) {
+		case fhir.Resource:
+			_ = fhirEncoder.Encode(v)
+		case fmt.Stringer:
+			_ = encoder.Encode(v.String())
+		default:
+			_ = encoder.Encode(v)
+		}
+	}
+}

--- a/fhirpath/trace/trace_test.go
+++ b/fhirpath/trace/trace_test.go
@@ -1,0 +1,113 @@
+package trace_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
+	ppb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/patient_go_proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/verily-src/fhirpath-go/fhirpath/system"
+	"github.com/verily-src/fhirpath-go/fhirpath/trace"
+	"github.com/verily-src/fhirpath-go/internal/fhir"
+)
+
+func TestWriterTracer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		prefix string
+		input  system.Collection
+		want   string
+	}{
+		{
+			name:  "Input is empty collection",
+			input: system.Collection{},
+			want:  "",
+		}, {
+			name:   "Input is system string",
+			prefix: "test-prefix",
+			input: system.Collection{
+				system.String("test string"),
+			},
+			want: "test-prefix:\n\"test string\"\n",
+		}, {
+			name:   "Input is system integer",
+			prefix: "test-prefix",
+			input: system.Collection{
+				system.Integer(42),
+			},
+			want: "test-prefix:\n42\n",
+		}, {
+			name:   "Input is system boolean",
+			prefix: "test-prefix",
+			input: system.Collection{
+				system.Boolean(true),
+			},
+			want: "test-prefix:\ntrue\n",
+		}, {
+			name:   "Input is date",
+			prefix: "test-prefix",
+			input: system.Collection{
+				system.MustParseDate("2024-01-02"),
+			},
+			want: "test-prefix:\n\"2024-01-02\"\n",
+		}, {
+			name:   "Input is resource",
+			prefix: "test-prefix",
+			input: system.Collection{
+				&ppb.Patient{
+					Name: []*dtpb.HumanName{
+						{
+							Given: []*dtpb.String{fhir.String("John")},
+						},
+					},
+				},
+			},
+			want: `test-prefix:
+{
+  "name": [
+    {
+      "given": [
+        "John"
+      ]
+    }
+  ],
+  "resourceType": "Patient"
+}
+`,
+		}, {
+			name:   "Multiple inputs",
+			prefix: "multiple",
+			input: system.Collection{
+				system.String("string value"),
+				system.Integer(100),
+				system.Boolean(false),
+			},
+			want: `multiple:
+"string value"
+100
+false
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var sb strings.Builder
+			sut := &trace.WriterTracer{
+				Out: &sb,
+			}
+			ctx := context.Background()
+
+			sut.Trace(ctx, tc.prefix, tc.input)
+
+			if got, want := sb.String(), tc.want; !cmp.Equal(got, want) {
+				t.Errorf("Trace() mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/fhirpath/trace/tracetest/tracetest.go
+++ b/fhirpath/trace/tracetest/tracetest.go
@@ -1,0 +1,26 @@
+package tracetest
+
+import (
+	"context"
+
+	"github.com/verily-src/fhirpath-go/fhirpath/system"
+)
+
+// Recorder is a simple implementation of [trace.Tracer] that records
+// trace events in memory for later inspection.
+type Recorder struct {
+	entries map[string]system.Collection
+}
+
+// Trace records a trace event with the given name and value.
+func (r *Recorder) Trace(_ context.Context, name string, value system.Collection) {
+	if r.entries == nil {
+		r.entries = make(map[string]system.Collection)
+	}
+	r.entries[name] = value
+}
+
+// Collection returns the recorded collection for the given trace name.
+func (r *Recorder) Collection(name string) system.Collection {
+	return r.entries[name]
+}

--- a/internal/fhir/elements_primitive.go
+++ b/internal/fhir/elements_primitive.go
@@ -7,8 +7,10 @@ import (
 	"regexp"
 
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
-	"github.com/google/uuid"
+
 	"github.com/verily-src/fhirpath-go/internal/slices"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -340,4 +342,13 @@ func UUID(value string) *dtpb.Uuid {
 // See: http://hl7.org/fhir/R4/datatypes.html#uuid
 func RandomUUID() *dtpb.Uuid {
 	return UUID(uuid.NewString())
+}
+
+// Xhtml creates an R4 FHIR XHTML element from a string value.
+//
+// See: https://hl7.org/fhir/R4/narrative.html#xhtml
+func Xhtml(value string) *dtpb.Xhtml {
+	return &dtpb.Xhtml{
+		Value: value,
+	}
 }

--- a/internal/fhir/elements_primitive_test.go
+++ b/internal/fhir/elements_primitive_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/verily-src/fhirpath-go/internal/element/canonical"
 	"github.com/verily-src/fhirpath-go/internal/fhir"
 	"github.com/verily-src/fhirpath-go/internal/slices"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestBase64Binary(t *testing.T) {
@@ -384,6 +386,28 @@ func TestURIFromUUID(t *testing.T) {
 
 			if got, want := got.GetValue(), tc.value.GetValue(); got != want {
 				t.Errorf("URIFromUUID(%v): got %v, want %v", tc.name, got, want)
+			}
+		})
+	}
+}
+
+func TestXhtml(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "Basic",
+			value: "xhtml",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sut := fhir.Xhtml(tc.value)
+
+			if got := sut.GetValue(); !cmp.Equal(got, tc.value) {
+				t.Errorf("Xhtml(%v): got %v, want %v", tc.value, got, tc.value)
 			}
 		})
 	}

--- a/internal/protofields/fields.go
+++ b/internal/protofields/fields.go
@@ -1,13 +1,14 @@
 package protofields
 
 import (
-	"strings"
-
+	apb "github.com/google/fhir/go/proto/google/fhir/proto/annotations_go_proto"
 	dtpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
 	bcrpb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
-	"github.com/iancoleman/strcase"
-	"github.com/verily-src/fhirpath-go/internal/slices"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/verily-src/fhirpath-go/internal/slices"
+
+	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -105,13 +106,18 @@ func UnwrapOneofField(element proto.Message, fieldName string) proto.Message {
 // Codes with enum values and string values are both considered valid.
 func IsCodeField(message proto.Message) bool {
 	reflect := message.ProtoReflect()
-	name := string(reflect.Descriptor().Name())
+
+	if !proto.HasExtension(reflect.Descriptor().Options(), apb.E_FhirValuesetUrl) {
+		return false
+	}
+
 	field := reflect.Descriptor().Fields().ByName(protoreflect.Name("value"))
 	if field != nil {
 		allowedKinds := []protoreflect.Kind{protoreflect.EnumKind, protoreflect.StringKind}
 		isValidFieldType := slices.Includes(allowedKinds, field.Kind())
-		return strings.HasSuffix(name, "Code") && isValidFieldType
+		return isValidFieldType
 	}
+
 	return false
 }
 


### PR DESCRIPTION
This PR includes the following:

- https://github.com/verily-src/fhirpath-go/pull/28 by Marwan Tammam (@Quarz0) & integrated by Alexander Sullivan (@AlexJSully)
- Implement `trace` by Matthew Rodusek (@bitwizeshift)

GitOrigin-RevId: fc3b4a26d79eb6840d54ab386cc15368e8a0393f